### PR TITLE
feat: integrar autenticación Auth0 para frontend (React) y backend (Express)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
-# SAGI (Sistema de Administracion de Gestion e Inventario)
-SAGI (Inventory and Management System for Healthcare Providers) is a web-based application designed to optimize inventory control, traceability, and internal supply management for healthcare institutions.
+# SAGI (Sistema de Administración de Gestión e Inventario)
+
+SAGI (Inventory and Management System for Healthcare Providers) es una aplicación web para optimizar control de inventario, trazabilidad y gestión interna de insumos.
+
+## Módulo de autenticación con Auth0
+
+Se agregó una implementación base de autenticación para:
+
+- **Frontend React (Vite)** usando Authorization Code Flow + PKCE.
+- **Backend Express** validando access tokens JWT RS256 con llaves públicas de Auth0 (JWKS).
+
+## 1) Configuración en Auth0
+
+1. Crea una **Single Page Application** para el frontend.
+2. Crea una **API** para el backend y copia su `Identifier` (audience).
+3. En la SPA configura:
+   - **Allowed Callback URLs**: `http://localhost:5173`
+   - **Allowed Logout URLs**: `http://localhost:5173`
+   - **Allowed Web Origins**: `http://localhost:5173`
+
+## 2) Variables de entorno
+
+### Backend (`backend/.env`)
+
+```env
+PORT=3000
+FRONTEND_ORIGIN=http://localhost:5173
+AUTH0_DOMAIN=tu-tenant.us.auth0.com
+AUTH0_AUDIENCE=https://sagi-api
+# Opcional (si no se define se construye con AUTH0_DOMAIN)
+AUTH0_ISSUER=https://tu-tenant.us.auth0.com/
+```
+
+### Frontend (`frontend/.env`)
+
+```env
+VITE_API_BASE_URL=http://localhost:3000
+VITE_AUTH0_DOMAIN=tu-tenant.us.auth0.com
+VITE_AUTH0_CLIENT_ID=tu_client_id_spa
+VITE_AUTH0_AUDIENCE=https://sagi-api
+VITE_AUTH0_REDIRECT_URI=http://localhost:5173
+```
+
+## 3) Rutas disponibles
+
+### Backend
+
+- `GET /api/public` → ruta sin autenticación.
+- `GET /api/protected` → requiere bearer token válido.
+- `GET /api/admin` → requiere token válido y scope `read:admin`.
+
+### Frontend
+
+- Botón **Iniciar sesión con Auth0** para redirigir al login.
+- Botón **Llamar /api/protected** para probar la API protegida con token.
+
+## 4) Ejecución local
+
+```bash
+# Terminal 1
+cd backend
+npm run dev
+
+# Terminal 2
+cd frontend
+npm run dev
+```

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -3,5 +3,11 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 export const NODE_ENV = process.env.NODE_ENV || 'development';
-export const PORT = process.env.PORT || 3000;
+export const PORT = Number(process.env.PORT || 3000);
 export const DATABASE_URL = process.env.DATABASE_URL;
+export const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+
+export const AUTH0_DOMAIN = process.env.AUTH0_DOMAIN || '';
+export const AUTH0_AUDIENCE = process.env.AUTH0_AUDIENCE || '';
+export const AUTH0_ISSUER =
+  process.env.AUTH0_ISSUER || (AUTH0_DOMAIN ? `https://${AUTH0_DOMAIN}/` : '');

--- a/backend/src/lib/auth0Jwt.js
+++ b/backend/src/lib/auth0Jwt.js
@@ -1,0 +1,103 @@
+import crypto from 'crypto';
+import { AUTH0_AUDIENCE, AUTH0_DOMAIN, AUTH0_ISSUER } from '../config/env.js';
+
+const encoder = new TextEncoder();
+const keyCache = new Map();
+
+const toBase64 = (value) => value.replace(/-/g, '+').replace(/_/g, '/');
+
+const decodeBase64Url = (value) => {
+  const padded = value.padEnd(Math.ceil(value.length / 4) * 4, '=');
+  return Buffer.from(toBase64(padded), 'base64');
+};
+
+const parseToken = (token) => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Token JWT inválido.');
+  }
+
+  const [headerPart, payloadPart, signaturePart] = parts;
+  const header = JSON.parse(decodeBase64Url(headerPart).toString('utf8'));
+  const payload = JSON.parse(decodeBaseUrl(payloadPart));
+
+  return {
+    header,
+    payload,
+    signature: decodeBase64Url(signaturePart),
+    signingInput: encoder.encode(`${headerPart}.${payloadPart}`),
+  };
+};
+
+const decodeBaseUrl = (value) => decodeBase64Url(value).toString('utf8');
+
+const loadKey = async (kid) => {
+  if (!AUTH0_DOMAIN) {
+    throw new Error('Falta AUTH0_DOMAIN en variables de entorno del backend.');
+  }
+
+  if (keyCache.has(kid)) {
+    return keyCache.get(kid);
+  }
+
+  const response = await fetch(`https://${AUTH0_DOMAIN}/.well-known/jwks.json`);
+  if (!response.ok) {
+    throw new Error('No fue posible descargar el JWKS de Auth0.');
+  }
+
+  const { keys = [] } = await response.json();
+  const jwk = keys.find((candidate) => candidate.kid === kid);
+
+  if (!jwk) {
+    throw new Error('No se encontró una llave pública válida para el token.');
+  }
+
+  const publicKey = crypto.createPublicKey({ key: jwk, format: 'jwk' });
+  keyCache.set(kid, publicKey);
+
+  return publicKey;
+};
+
+const validateClaims = (payload) => {
+  const now = Math.floor(Date.now() / 1000);
+
+  if (!payload.exp || payload.exp <= now) {
+    throw new Error('El token está expirado.');
+  }
+
+  if (payload.nbf && payload.nbf > now) {
+    throw new Error('El token todavía no es válido.');
+  }
+
+  if (!AUTH0_ISSUER || payload.iss !== AUTH0_ISSUER) {
+    throw new Error('Issuer de token inválido.');
+  }
+
+  if (!AUTH0_AUDIENCE) {
+    throw new Error('Falta AUTH0_AUDIENCE en variables de entorno del backend.');
+  }
+
+  const audiences = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (!audiences.includes(AUTH0_AUDIENCE)) {
+    throw new Error('Audience de token inválido.');
+  }
+};
+
+export const verifyAuth0Token = async (token) => {
+  const { header, payload, signature, signingInput } = parseToken(token);
+
+  if (header.alg !== 'RS256' || !header.kid) {
+    throw new Error('Algoritmo JWT no soportado.');
+  }
+
+  const key = await loadKey(header.kid);
+
+  const verified = crypto.verify('RSA-SHA256', signingInput, key, signature);
+  if (!verified) {
+    throw new Error('Firma de token inválida.');
+  }
+
+  validateClaims(payload);
+
+  return payload;
+};

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,40 @@
+import { verifyAuth0Token } from '../lib/auth0Jwt.js';
+
+const bearerPrefix = 'Bearer ';
+
+export const requireAuth = async (req, res, next) => {
+  try {
+    const authorization = req.headers.authorization || '';
+
+    if (!authorization.startsWith(bearerPrefix)) {
+      return res.status(401).json({
+        error: 'missing_token',
+        message: 'Debes enviar un access token en el header Authorization.',
+      });
+    }
+
+    const token = authorization.slice(bearerPrefix.length).trim();
+    const payload = await verifyAuth0Token(token);
+
+    req.auth = payload;
+    return next();
+  } catch (error) {
+    return res.status(401).json({
+      error: 'invalid_token',
+      message: error.message,
+    });
+  }
+};
+
+export const requireScope = (scope) => (req, res, next) => {
+  const scopes = (req.auth?.scope || '').split(' ').filter(Boolean);
+
+  if (!scopes.includes(scope)) {
+    return res.status(403).json({
+      error: 'insufficient_scope',
+      message: `Se requiere el scope "${scope}" para acceder a este recurso.`,
+    });
+  }
+
+  return next();
+};

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { requireAuth, requireScope } from '../middleware/auth.js';
+
+const router = Router();
+
+router.get('/public', (req, res) => {
+  res.json({
+    message: 'Ruta pública accesible sin autenticación.',
+    ts: new Date().toISOString(),
+  });
+});
+
+router.get('/protected', requireAuth, (req, res) => {
+  res.json({
+    message: 'Acceso autorizado mediante Auth0.',
+    user: {
+      sub: req.auth.sub,
+      scope: req.auth.scope || '',
+    },
+  });
+});
+
+router.get('/admin', requireAuth, requireScope('read:admin'), (req, res) => {
+  res.json({
+    message: 'Ruta con scope read:admin autorizado.',
+  });
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,8 +1,22 @@
-import { PORT } from './config/env.js';
 import express from 'express';
-//const express = require('express')
-const app = express()
-//const port = process.env.PORT
+import { FRONTEND_ORIGIN, PORT } from './config/env.js';
+import authRoutes from './routes/authRoutes.js';
+
+const app = express();
+
+app.use(express.json());
+
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', FRONTEND_ORIGIN);
+  res.header('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+
+  return next();
+});
 
 app.get('/', (req, res) => {
   res.send('SAGI API is running OK 🚀');
@@ -12,6 +26,8 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
+app.use('/api', authRoutes);
+
 app.listen(PORT, () => {
-  console.log(`Example app listening on port ${PORT}`)
-})
+  console.log(`SAGI backend listening on port ${PORT}`);
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,54 @@
 #root {
-  max-width: 1280px;
+  max-width: 860px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.container h1 {
+  margin-bottom: 0.25rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.subtitle {
+  color: #465569;
+  margin-top: 0;
 }
 
 .card {
-  padding: 2em;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin: 1rem 0;
+  background: #fff;
 }
 
-.read-the-docs {
-  color: #888;
+button {
+  border-radius: 8px;
+  border: 1px solid transparent;
+  padding: 0.6em 1.2em;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background-color: #111827;
+  color: white;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+pre {
+  margin-top: 1rem;
+  border-radius: 8px;
+  background: #111827;
+  color: #e5e7eb;
+  padding: 1rem;
+  overflow-x: auto;
+  font-size: 0.8rem;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,35 +1,71 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from 'react';
+import { useAuth } from './auth/useAuth.js';
+import './App.css';
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { isAuthenticated, isLoading, user, login, logout, accessToken, error } = useAuth();
+  const [protectedResult, setProtectedResult] = useState('');
+  const [requestError, setRequestError] = useState('');
+
+  const callProtectedApi = async () => {
+    try {
+      setRequestError('');
+      const response = await fetch(`${apiBaseUrl}/api/protected`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.message || 'No se pudo consultar la ruta protegida.');
+      }
+
+      setProtectedResult(JSON.stringify(data, null, 2));
+    } catch (apiError) {
+      setRequestError(apiError.message);
+      setProtectedResult('');
+    }
+  };
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
+    <main className="container">
+      <h1>Autenticación Auth0 (React + Express)</h1>
+      <p className="subtitle">
+        Demo de login con Auth0 desde frontend y validación JWT en backend.
       </p>
-    </>
-  )
+
+      {isLoading ? <p>Cargando estado de autenticación...</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      <section className="card">
+        <h2>Sesión</h2>
+        {isAuthenticated ? (
+          <>
+            <p>
+              <strong>Usuario:</strong> {user?.name || user?.email || user?.sub}
+            </p>
+            <button onClick={logout}>Cerrar sesión</button>
+          </>
+        ) : (
+          <button onClick={login}>Iniciar sesión con Auth0</button>
+        )}
+      </section>
+
+      <section className="card">
+        <h2>API protegida</h2>
+        <p>Esta acción envía el access token al backend Express.</p>
+        <button disabled={!isAuthenticated} onClick={callProtectedApi}>
+          Llamar /api/protected
+        </button>
+        {requestError ? <p className="error">{requestError}</p> : null}
+        {protectedResult ? <pre>{protectedResult}</pre> : null}
+      </section>
+    </main>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/auth/AuthProvider.jsx
+++ b/frontend/src/auth/AuthProvider.jsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AuthContext } from './authContextValue.js';
+import {
+  exchangeCodeForToken,
+  loginWithRedirect,
+  logoutWithRedirect,
+  parseJwtPayload,
+} from './auth0Client';
+
+const tokenStorageKey = 'auth_access_token';
+
+export const AuthProvider = ({ children }) => {
+  const [accessToken, setAccessToken] = useState(localStorage.getItem(tokenStorageKey) || '');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const bootAuth = async () => {
+      try {
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        const state = params.get('state');
+
+        if (code && state) {
+          const tokenResponse = await exchangeCodeForToken(code, state);
+          localStorage.setItem(tokenStorageKey, tokenResponse.access_token);
+          setAccessToken(tokenResponse.access_token);
+
+          const cleanUrl = `${window.location.origin}${window.location.pathname}`;
+          window.history.replaceState({}, document.title, cleanUrl);
+        }
+      } catch (authError) {
+        setError(authError.message);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    bootAuth();
+  }, []);
+
+  const login = async () => {
+    setError('');
+    await loginWithRedirect();
+  };
+
+  const logout = () => {
+    localStorage.removeItem(tokenStorageKey);
+    setAccessToken('');
+    logoutWithRedirect();
+  };
+
+  const user = useMemo(() => parseJwtPayload(accessToken), [accessToken]);
+
+  return (
+    <AuthContext.Provider
+      value={{
+        accessToken,
+        user,
+        isAuthenticated: Boolean(accessToken),
+        isLoading,
+        error,
+        login,
+        logout,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/src/auth/auth0Client.js
+++ b/frontend/src/auth/auth0Client.js
@@ -1,0 +1,127 @@
+const domain = import.meta.env.VITE_AUTH0_DOMAIN;
+const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
+const audience = import.meta.env.VITE_AUTH0_AUDIENCE;
+const redirectUri =
+  import.meta.env.VITE_AUTH0_REDIRECT_URI || window.location.origin;
+
+const stateKey = 'auth0_state';
+const verifierKey = 'auth0_code_verifier';
+
+const asBase64Url = (arrayBuffer) => {
+  const bytes = new Uint8Array(arrayBuffer);
+  let binary = '';
+
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const generateRandomString = (length = 64) => {
+  const charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const randomValues = new Uint8Array(length);
+  crypto.getRandomValues(randomValues);
+
+  return Array.from(randomValues, (value) => charset[value % charset.length]).join('');
+};
+
+const ensureConfig = () => {
+  const missing = [
+    !domain && 'VITE_AUTH0_DOMAIN',
+    !clientId && 'VITE_AUTH0_CLIENT_ID',
+    !audience && 'VITE_AUTH0_AUDIENCE',
+  ].filter(Boolean);
+
+  if (missing.length) {
+    throw new Error(`Faltan variables Auth0 en frontend: ${missing.join(', ')}`);
+  }
+};
+
+const createCodeChallenge = async (verifier) => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  return asBase64Url(digest);
+};
+
+export const loginWithRedirect = async () => {
+  ensureConfig();
+
+  const verifier = generateRandomString(96);
+  const challenge = await createCodeChallenge(verifier);
+  const state = generateRandomString(32);
+
+  sessionStorage.setItem(verifierKey, verifier);
+  sessionStorage.setItem(stateKey, state);
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    scope: 'openid profile email',
+    audience,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    state,
+  });
+
+  window.location.assign(`https://${domain}/authorize?${params.toString()}`);
+};
+
+export const exchangeCodeForToken = async (code, incomingState) => {
+  ensureConfig();
+
+  const savedState = sessionStorage.getItem(stateKey);
+  const verifier = sessionStorage.getItem(verifierKey);
+
+  if (!savedState || incomingState !== savedState || !verifier) {
+    throw new Error('No se pudo validar el estado de autenticación (state/PKCE).');
+  }
+
+  const response = await fetch(`https://${domain}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      code,
+      code_verifier: verifier,
+      redirect_uri: redirectUri,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Error al intercambiar el código de Auth0 por tokens.');
+  }
+
+  sessionStorage.removeItem(stateKey);
+  sessionStorage.removeItem(verifierKey);
+
+  return response.json();
+};
+
+export const logoutWithRedirect = () => {
+  ensureConfig();
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    returnTo: window.location.origin,
+  });
+
+  window.location.assign(`https://${domain}/v2/logout?${params.toString()}`);
+};
+
+export const parseJwtPayload = (token) => {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const payload = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+  const normalized = payload.padEnd(Math.ceil(payload.length / 4) * 4, '=');
+
+  try {
+    return JSON.parse(atob(normalized));
+  } catch {
+    return null;
+  }
+};

--- a/frontend/src/auth/authContextValue.js
+++ b/frontend/src/auth/authContextValue.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext(null);

--- a/frontend/src/auth/useAuth.js
+++ b/frontend/src/auth/useAuth.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from './authContextValue.js';
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth debe usarse dentro de AuthProvider.');
+  }
+  return context;
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,20 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #111827;
+  background-color: #f3f4f6;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.jsx';
+import { AuthProvider } from './auth/AuthProvider.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
-)
+);


### PR DESCRIPTION
### Motivation
- Añadir un módulo de autenticación centralizado para proteger la API y la UI mediante Auth0 y tokens JWT RS256.
- Implementar en el frontend SPA el flujo Authorization Code + PKCE compatible con Auth0 y sin librerías externas para mantener control del flujo.
- Validar tokens en el backend con JWKS para comprobar firma y claims (`iss`, `aud`, `exp`, `nbf`) antes de exponer recursos protegidos.

### Description
- Backend: se añadieron variables de entorno (`AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, `AUTH0_ISSUER`, `FRONTEND_ORIGIN`) en `backend/src/config/env.js` y CORS básico en `backend/src/server.js` para permitir el frontend.
- Backend: nuevo helper `backend/src/lib/auth0Jwt.js` que descarga el JWKS de Auth0, construye la llave pública y verifica firma RS256 y claims del access token.
- Backend: middlewares `requireAuth` y `requireScope` en `backend/src/middleware/auth.js` y rutas de ejemplo (public/protected/admin) en `backend/src/routes/authRoutes.js` montadas bajo `/api`.
- Frontend: cliente Auth0 en `frontend/src/auth/auth0Client.js` que genera `code_verifier`/`code_challenge` (PKCE), redirige a `/authorize`, intercambia `code` por tokens y gestiona `logout`.
- Frontend: `AuthProvider` + `useAuth` (`frontend/src/auth/AuthProvider.jsx`, `frontend/src/auth/useAuth.js`, `frontend/src/auth/authContextValue.js`) y envoltorio en `frontend/src/main.jsx` para exponer `login`, `logout`, `accessToken` y `user` a la app.
- Frontend: UI y estilos actualizados (`frontend/src/App.jsx`, `frontend/src/App.css`, `frontend/src/index.css`) con botones para iniciar/cerrar sesión y probar la llamada a `/api/protected` enviando el `Authorization: Bearer`.
- Documentación: `README.md` actualizado con pasos de configuración en Auth0, variables de entorno y comandos de ejecución local.
- Nota: no se añadieron dependencias externas al proyecto; la verificación JWT se implementó con APIs nativas por una restricción de acceso al registry en este entorno.

### Testing
- Se validaron los archivos Node con `node --check` para `src/server.js`, `src/lib/auth0Jwt.js`, `src/middleware/auth.js` y `src/routes/authRoutes.js`, y la comprobación pasó correctamente. 
- Se ejecutó el linter con `npm run lint` en el frontend y después de mover el contexto a archivos separados el linter pasó satisfactoriamente. 
- Se construyó el frontend con `npm run build` y la build fue exitosa. 
- Se levantó el backend localmente y se verificaron las rutas con `curl http://localhost:3000/health` y `curl http://localhost:3000/api/public`, ambas respondieron correctamente. 
- Se intentó instalar `express-oauth2-jwt-bearer` y `cors` con `npm install` pero la instalación falló por un `403 Forbidden` al registry, por lo que la integración fue implementada sin nuevas dependencias. 
- Se generó una captura de la UI ejecutando el frontend dev server y un script de Playwright para verificar visualmente la interfaz (captura guardada en `artifacts/auth0-ui.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699536ce5a38832e804780a8d91957a5)